### PR TITLE
Add support for subdocument array

### DIFF
--- a/lib/mosql/schema.rb
+++ b/lib/mosql/schema.rb
@@ -143,6 +143,16 @@ module MoSQL
       schema
     end
 
+    def fetch_piped(obj, piped)
+      pieces = piped.split("|")
+      attribute_name = pieces[0]
+      subdocument_attribute_name = pieces[1]
+      if obj[attribute_name].kind_of?(Array) and not obj[attribute_name].empty?
+        return obj[attribute_name][-1][subdocument_attribute_name]
+      end
+      return nil
+    end
+
     def fetch_and_delete_dotted(obj, dotted)
       pieces = dotted.split(".")
       breadcrumbs = []
@@ -219,6 +229,8 @@ module MoSQL
 
         if source.start_with?("$")
           v = fetch_special_source(obj, source, original)
+        elsif source.include?("|")
+          v = fetch_piped(obj, source)
         else
           v = fetch_and_delete_dotted(obj, source)
           case v


### PR DESCRIPTION
Added a pipe delimited notation to handle subdocument arrays.
usage
In collection.yml:
- drivers_license_number:
:source: driverLicenses|licenseNumber
:type: TEXT

example
In a subdocument array like this, {... 'driverLicenses': [{... licenseNumber: 1 ...}, {... licenseNumber: 2 ...}, {... licenseNumber: 3 ...}] ... }
mosql will return the active license number, which is the highest indexed license number, 3